### PR TITLE
Add option to repair hum files that may cause NXT to lock up

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 - Process a single file or mutliple files at once
 - Process all `.wav` files in a directory/folder
 - Supports File Explorer drag-and-drop or command-line usage
-- Optionally trim sound files to Anima NXT-compatible lengths (Experimental)
+- Optionally trim long hum files to an Anima-friendly length
+- Detect and repair hum files that are likely to cause lockups in Anima NXTs (experimental)
 
 ## Program Usage
 ### Drag-and-Drop
@@ -39,8 +40,8 @@ options:
                         program will exit)
   -D, --debug           Show debugging information
   -N, --no-rename       do not attempt to rename output files to Polaris standards (e.g., CLASH_1_0.RAW)
-  -T, --trim            Trim output files to NXT-compatible lengths (Experimental)
-  -o, --outdir OUTDIR   put output files in specified directory (will be created if it does not exist)
+  -T, --trim            Trim hum files to NXT-friendly length
+  -H, --humfix          Attempt to repair hum files that may cause NXTs to lock up (experimental)
   -E, --exclude-unmatched
                         do not process files that cannot be matched to a standard Polaris filename
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ keywords = ["polaris", "ludosport", "lightsabers", "opencore"]
 dependencies = [
     "py-getch >= 1.0.1",
     "pydub >= 0.25.1",
-    "audioop-lts >= 0.2.1"
+    "audioop-lts >= 0.2.1",
+    "numpy >= 2.0.0"
 ]
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,4 +28,4 @@ requires-python = ">=3.10"
 Homepage = "https://github.com/jramboz/wav2polaris"
 
 [project.scripts]
-wav2polaris = "wav2polaris.wav2polaris:main_func"
+wav2polaris = "wav2polaris.app:main_func"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 py-getch >= 1.0.1
 pydub >= 0.25.1
 audioop-lts >= 0.2.1
+numpy >= 2.0.0

--- a/src/wav2polaris/__main__.py
+++ b/src/wav2polaris/__main__.py
@@ -1,4 +1,4 @@
-from . import wav2polaris
+from . import app
 
 if __name__ == "__main__":
-    wav2polaris.main_func()
+    app.main_func()

--- a/src/wav2polaris/app.py
+++ b/src/wav2polaris/app.py
@@ -6,12 +6,12 @@ import sys
 import platform
 import os
 import errno
-if __name__ == "__main__":
-    import utils  # ty:ignore[unresolved-import]
-    import sound  # ty:ignore[unresolved-import]
-else:
-    from . import utils
-    from . import sound
+# if __name__ == "__main__":
+#     import utils  # ty:ignore[unresolved-import]
+#     import sound  # ty:ignore[unresolved-import]
+# else:
+from wav2polaris import utils
+from wav2polaris import sound
 
 
 script_version = '0.4.1'
@@ -33,6 +33,7 @@ def main_func():
             #stream.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s: %(message)s'))
             stream.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
             log.addHandler(stream)
+    log.setLevel(logging.INFO)
     
     exit_code = 0
 
@@ -63,7 +64,10 @@ def main_func():
                         help='do not attempt to rename output files to Polaris standards (e.g., CLASH_1_0.RAW)')
     parser.add_argument('-T', '--trim',
                         action="store_true",
-                        help='Trim output files to NXT-compatible lengths (Experimental)')
+                        help='Trim hum files to NXT-friendly length')
+    parser.add_argument('-H', '--humfix',
+                        action='store_true',
+                        help='Attempt to repair hum files that may cause NXTs to lock up (experimental)')
     parser.add_argument('-o', '--outdir',
                         action='store', dest='outdir',
                         help='put output files in specified directory (will be created if it does not exist)')
@@ -131,7 +135,7 @@ def main_func():
                         outdir = args.outdir
 
                 if args.no_rename:
-                    output = sound.convert_wav_to_polaris_raw(file, outdir, args.trim)
+                    output = sound.convert_wav_to_polaris_raw(file, outdir, args.trim, args.humfix)
                 else:
                     destination = sound.get_polaris_filename(file)
                     log.debug(f'Auto-matching result: {os.path.basename(file)} -> {destination}')
@@ -141,7 +145,7 @@ def main_func():
                             continue # Go to the next file
                     target = os.path.join(outdir, destination)
                     log.debug(f'Destination output: {target}')
-                    output = sound.convert_wav_to_polaris_raw(file, target, args.trim)
+                    output = sound.convert_wav_to_polaris_raw(file, target, args.trim, args.humfix)
 
                 if output:
                     log.debug(f'Converted file successfully: {file} -> {output}')

--- a/src/wav2polaris/app.py
+++ b/src/wav2polaris/app.py
@@ -6,10 +6,6 @@ import sys
 import platform
 import os
 import errno
-# if __name__ == "__main__":
-#     import utils  # ty:ignore[unresolved-import]
-#     import sound  # ty:ignore[unresolved-import]
-# else:
 from wav2polaris import utils
 from wav2polaris import sound
 

--- a/src/wav2polaris/humfix.py
+++ b/src/wav2polaris/humfix.py
@@ -4,6 +4,7 @@
 # Code generated with help from Claud AI, but incorporated and checked by hand.
 
 from pydub import AudioSegment
+import numpy as np
 
 def get_sample_count(segment: AudioSegment) -> int:
     """Total number of audio frames (samples per channel) in the segment."""
@@ -23,6 +24,10 @@ def check_parity(segment: AudioSegment) -> dict:
         "predicted_safe": is_even,
     }
 
+def _segment_to_array(segment: AudioSegment) -> np.ndarray:
+    """Extract samples as a numpy array, dtype inferred from the segment's own format."""
+    return np.array(segment.get_array_of_samples())
+
 def repair_segment(segment: AudioSegment, position: float = 0.5,
                     crossfade_ms: int = 10) -> AudioSegment:
     """
@@ -33,29 +38,53 @@ def repair_segment(segment: AudioSegment, position: float = 0.5,
     loudness (dBFS) is matched to the input to avoid an audible level jump.
 
     This does not check whether the segment is actually flagged as
-    dangerous first.
+    dangerous first. Only mono audio is currently supported, matching the d
+    ocumented hum file format (16-bit, mono, 44.1kHz).
     """
-    duration_ms = len(segment)  # pydub AudioSegment length is in milliseconds
-
-    if duration_ms <= crossfade_ms * 2:
-        raise ValueError(
-            f"Segment too short ({duration_ms}ms) for a {crossfade_ms}ms crossfade splice."
+    if segment.channels != 1:
+        raise NotImplementedError(
+            "repair_segment() currently only supports mono audio "
+            f"(got {segment.channels} channels)."
         )
 
-    cut_ms = int(duration_ms * position)
+    n = get_sample_count(segment)
+    crossfade_samples = int(round(segment.frame_rate * crossfade_ms / 1000.0))
+
+    if n <= crossfade_samples * 2:
+        raise ValueError(
+            f"Segment too short ({n} samples) for a {crossfade_samples}-sample crossfade splice."
+        )
+
+    cut = int(n * position)
     # Keep the cut point away from the very start/end so there's room for
     # the crossfade window on both sides.
-    cut_ms = max(crossfade_ms + 1, min(duration_ms - crossfade_ms - 1, cut_ms))
+    cut = max(crossfade_samples + 1, min(n - crossfade_samples - 1, cut))
 
-    first_half = segment[:cut_ms]
-    second_half = segment[cut_ms:]
+    samples = _segment_to_array(segment)
+    dtype = samples.dtype
+    info = np.iinfo(dtype)
+
+    data = samples.astype(np.float64)
+    a = data[:cut]
+    b = data[cut:]
+
+    ramp = np.linspace(1, 0, crossfade_samples)
+    junction = a[-crossfade_samples:] * ramp + b[:crossfade_samples] * (1 - ramp)
+    spliced = np.concatenate([a[:-crossfade_samples], junction, b[crossfade_samples:]])
+
+    # This guarantees len(spliced) == n - crossfade_samples exactly, every
+    # time, regardless of position -- which is what makes the parity flip
+    # deterministic (unlike the pydub-ms-based approach this replaced).
 
     original_dbfs = segment.dBFS
 
-    spliced = first_half.append(second_half, crossfade=crossfade_ms)
+    spliced = np.clip(spliced, info.min, info.max)
+    spliced_int = spliced.astype(dtype)
 
-    # Preserve original loudness (append+crossfade can shift overall level slightly)
-    if original_dbfs != float("-inf") and spliced.dBFS != float("-inf"):
-        spliced = spliced.apply_gain(original_dbfs - spliced.dBFS)
+    new_segment = segment._spawn(spliced_int.tobytes())
 
-    return spliced
+    # Preserve original loudness (the blend can shift overall level slightly)
+    if original_dbfs != float("-inf") and new_segment.dBFS != float("-inf"):
+        new_segment = new_segment.apply_gain(original_dbfs - new_segment.dBFS)
+
+    return new_segment

--- a/src/wav2polaris/humfix.py
+++ b/src/wav2polaris/humfix.py
@@ -1,0 +1,61 @@
+# This file contains functions for detecting and repairint hum sounds that are 
+# likely to cause issues with Anima NXTs. 
+# 
+# Code generated with help from Claud AI, but incorporated and checked by hand.
+
+from pydub import AudioSegment
+
+def get_sample_count(segment: AudioSegment) -> int:
+    """Total number of audio frames (samples per channel) in the segment."""
+    return int(segment.frame_count())
+
+def check_parity(segment: AudioSegment) -> dict:
+    """
+    Check a segment's raw sample count parity and return a prediction.
+
+    Returns a dict: {"samples": int, "parity": "even"|"odd", "predicted_safe": bool}
+    """
+    n = get_sample_count(segment)
+    is_even = (n % 2 == 0)
+    return {
+        "samples": n,
+        "parity": "even" if is_even else "odd",
+        "predicted_safe": is_even,
+    }
+
+def repair_segment(segment: AudioSegment, position: float = 0.5,
+                    crossfade_ms: int = 10) -> AudioSegment:
+    """
+    Unconditionally apply a single crossfade splice repair to `segment`.
+
+    Cuts the segment at `position` (fraction of total duration, 0-1) and
+    rejoins the two pieces with a `crossfade_ms` linear crossfade. Output
+    loudness (dBFS) is matched to the input to avoid an audible level jump.
+
+    This does not check whether the segment is actually flagged as
+    dangerous first.
+    """
+    duration_ms = len(segment)  # pydub AudioSegment length is in milliseconds
+
+    if duration_ms <= crossfade_ms * 2:
+        raise ValueError(
+            f"Segment too short ({duration_ms}ms) for a {crossfade_ms}ms crossfade splice."
+        )
+
+    cut_ms = int(duration_ms * position)
+    # Keep the cut point away from the very start/end so there's room for
+    # the crossfade window on both sides.
+    cut_ms = max(crossfade_ms + 1, min(duration_ms - crossfade_ms - 1, cut_ms))
+
+    first_half = segment[:cut_ms]
+    second_half = segment[cut_ms:]
+
+    original_dbfs = segment.dBFS
+
+    spliced = first_half.append(second_half, crossfade=crossfade_ms)
+
+    # Preserve original loudness (append+crossfade can shift overall level slightly)
+    if original_dbfs != float("-inf") and spliced.dBFS != float("-inf"):
+        spliced = spliced.apply_gain(original_dbfs - spliced.dBFS)
+
+    return spliced

--- a/src/wav2polaris/sound.py
+++ b/src/wav2polaris/sound.py
@@ -104,19 +104,18 @@ def convert_wav_to_polaris_raw(input: str, output: str | None = None, nxt_trim: 
 
         # Special processing for hum files to avoid NXT lockups.
         # Check whether or not the file is likely safe and warn the user.
+        # User always gets the warning if file is likely unsafe, but fix is
+        # only applied if specifically requested.
         predicted_safe = humfix.check_parity(sound)["predicted_safe"]
         is_hum = utils.is_hum(os.path.basename(output))
         if is_hum and predicted_safe:
             _log.debug("Hum file is likely safe for Anima NXT.")
         elif is_hum and not predicted_safe:
             _log.warning("Hum file is likely to cause problems with Anima NXT.")
-
-        # Apply hum fix if requested and file appears to need it.
-        # This is purposely separate from the hum check above so that you can
-        # apply the fix to any file, if desired, not just hums.
-        if apply_humfix and not predicted_safe:
-            _log.info(f"Applying hum fix to file {input}")
-            sound = humfix.repair_segment(sound)
+            # Apply hum fix if requested.
+            if apply_humfix:
+                _log.info(f"Applying hum fix to file {input}")
+                sound = humfix.repair_segment(sound)
 
         # trim silence from beginning and end
         # sound = trim_edges(sound)

--- a/src/wav2polaris/sound.py
+++ b/src/wav2polaris/sound.py
@@ -7,6 +7,8 @@ import os
 import logging
 import re
 import typing
+from wav2polaris import humfix
+from wav2polaris import utils
 
 # Created this to trim silence from the beginning and end, but ended up deciding not to use this.
 # This was part of trying to determine whether the silence was causing (even partly) the anima
@@ -24,12 +26,13 @@ import typing
 #     trimmed = trim_start(trimmed.reverse()).reverse()
 #     return trimmed
 
-def convert_wav_to_polaris_raw(input: str, output: str | None = None, nxt_trim: bool = False) -> str | None:
+def convert_wav_to_polaris_raw(input: str, output: str | None = None, nxt_trim: bool = False, apply_humfix: bool = False) -> str | None:
     '''Converts a wav file to a raw file with the appropriate parameters for use in a Polaris Anima.
     If no output path/filename is specified, it will use the input filename with '.RAW' in the same directory.
     Returns filename (with path) if successful. Returns None if failed.
     
-    If nxt_trim is True, output files will be trimmed to NXT-compatible lenghts. Note that this will only work with the standard naming scheme.'''
+    If nxt_trim is True, hum files will be trimmed to an NXT-friendly length. Note that this will only work with the standard naming scheme.
+    If apply_humfix is true, it will attempt to repair hums that could cause NXTs to lock up.'''
     _log = logging.getLogger('Sound')
 
     # Polaris compatible sound specifications
@@ -38,9 +41,12 @@ def convert_wav_to_polaris_raw(input: str, output: str | None = None, nxt_trim: 
     _BIT_DEPTH = 2 # 16-bit
 
     # NXT-compatible sound lengths (in milliseconds)
-    _NXT_HUM_LENGTH = 19.9 * 1000
-    _NXT_SWING_LENGTH = 5.9 * 1000
-    _NXT_POWERON_LENGTH = 2.9 * 1000
+    _NXT_HUM_LENGTH = 20 * 1000
+    # _NXT_SWING_LENGTH = 5.9 * 1000
+    # _NXT_POWERON_LENGTH = 2.9 * 1000
+    # After further investigation, the sound length does not seem to be a determinative factor.
+    # I'm still going to (optionally) trim the Hum because I think it's more space efficient.
+    # I may revisit this later.
 
     try:
         #open the file
@@ -79,21 +85,38 @@ def convert_wav_to_polaris_raw(input: str, output: str | None = None, nxt_trim: 
         if os.path.isdir(output):
             output = os.path.join(output, os.path.splitext(os.path.basename(input))[0] + '.RAW')
 
-        # if requested, trim files to length that works with NXTs
+        # if requested, trim files to length that works with NXTs (but see note above)
+        # Update: if we stay with trimming only hums, this could be folded into the next check below.
         if nxt_trim:
             # figure out effect type based on filename. Will only work with default naming scheme
             # I might make this more robust using regex patters to match any filename, but that will come later.
             if "HUM_" in output:
                 trim_length = _NXT_HUM_LENGTH
-            elif "SMOOTHSWING" in output:
-                trim_length = _NXT_SWING_LENGTH
-            elif "POWERON" in output:
-                trim_length = _NXT_POWERON_LENGTH
+            # elif "SMOOTHSWING" in output:
+            #     trim_length = _NXT_SWING_LENGTH
+            # elif "POWERON" in output:
+            #     trim_length = _NXT_POWERON_LENGTH
             else:
                 trim_length = 0
             # trim the file
             if trim_length:
                 sound = sound[:trim_length]
+
+        # Special processing for hum files to avoid NXT lockups.
+        # Check whether or not the file is likely safe and warn the user.
+        predicted_safe = humfix.check_parity(sound)["predicted_safe"]
+        is_hum = utils.is_hum(os.path.basename(output))
+        if is_hum and predicted_safe:
+            _log.debug("Hum file is likely safe for Anima NXT.")
+        elif is_hum and not predicted_safe:
+            _log.warning("Hum file is likely to cause problems with Anima NXT.")
+
+        # Apply hum fix if requested and file appears to need it.
+        # This is purposely separate from the hum check above so that you can
+        # apply the fix to any file, if desired, not just hums.
+        if apply_humfix and not predicted_safe:
+            _log.info(f"Applying hum fix to file {input}")
+            sound = humfix.repair_segment(sound)
 
         # trim silence from beginning and end
         # sound = trim_edges(sound)
@@ -108,6 +131,7 @@ def convert_wav_to_polaris_raw(input: str, output: str | None = None, nxt_trim: 
         return None
 
 # This next bit is to attempt to automatically translate source sound font names to Polaris default names using regexps.
+# TODO: refactor this into utils.py. It makes more sense there.
 class _Effect_RE(object):
     '''Holds regular expressions for pattern matching during file conversion'''
     # yeah, this is probably overkill as a data structure, but it makes the code read easier when it gets to regexp matching time

--- a/src/wav2polaris/sound.py
+++ b/src/wav2polaris/sound.py
@@ -7,8 +7,8 @@ import os
 import logging
 import re
 import typing
-from wav2polaris import humfix
-from wav2polaris import utils
+from . import humfix
+from . import utils
 
 # Created this to trim silence from the beginning and end, but ended up deciding not to use this.
 # This was part of trying to determine whether the silence was causing (even partly) the anima

--- a/src/wav2polaris/sound.py
+++ b/src/wav2polaris/sound.py
@@ -2,10 +2,27 @@ import warnings
 with warnings.catch_warnings(): #pydub prints a warning if ffmpeg or avlib aren't installed, but we don't care
     warnings.simplefilter('ignore')
     from pydub import AudioSegment
+    # from pydub.silence import detect_leading_silence
 import os
 import logging
 import re
 import typing
+
+# Created this to trim silence from the beginning and end, but ended up deciding not to use this.
+# This was part of trying to determine whether the silence was causing (even partly) the anima
+# lockups. I ended up finding that it was not the determining factor, so I decided not to
+# keep it. I may add it in later as an option.
+# def trim_edges(sound, silence_threshold=-40.0):
+#     # Function to find where leading silence ends
+#     def trim_start(audio):
+#         start_trim = detect_leading_silence(audio, silence_threshold=silence_threshold)
+#         return audio[start_trim:]
+
+#     # Trim the front
+#     trimmed = trim_start(sound)
+#     # Reverse, trim the front (which is the original back), and reverse back
+#     trimmed = trim_start(trimmed.reverse()).reverse()
+#     return trimmed
 
 def convert_wav_to_polaris_raw(input: str, output: str | None = None, nxt_trim: bool = False) -> str | None:
     '''Converts a wav file to a raw file with the appropriate parameters for use in a Polaris Anima.
@@ -76,7 +93,10 @@ def convert_wav_to_polaris_raw(input: str, output: str | None = None, nxt_trim: 
                 trim_length = 0
             # trim the file
             if trim_length:
-                sound = sound[:trim_length] # type: ignore
+                sound = sound[:trim_length]
+
+        # trim silence from beginning and end
+        # sound = trim_edges(sound)
 
         # write output file
         _log.debug(f'Writing output file: {output}')

--- a/src/wav2polaris/utils.py
+++ b/src/wav2polaris/utils.py
@@ -17,3 +17,13 @@ def is_polaris_filename(filename: str) -> bool:
         if re.match(pattern, filename):
             return True
     return False
+
+# Function to determine if a file is a hum. Assume anything starting with
+# "hum" or "HUM" is a hum.
+HUM_REGEX = r"^hum.*$"
+
+def is_hum(filename: str) -> bool:
+    if re.match(HUM_REGEX, filename, re.I):
+        return True
+    else:
+        return False


### PR DESCRIPTION
This PR adds logic to determine if a hum file is likely to cause an Anima NXT to lock up, and optionally patch the file to make it safe.

After extensive testing, I determined that the cause of the lockup was hum files with an odd number of audio samples. However, simply adding or deleting samples to make the parity even does not repair the file. What does work is adding a single 10ms crossfade splice somewhere in the middle of the .RAW sound file. Why does it work? I'm not entirely sure--but it does work in every case I am able to test.

This should serve as a workaround for jramboz/tintalle#15 and jramboz/py2saber#2.